### PR TITLE
feat: canonical and og tags, pointing at pvin.is

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,25 @@
 <head>
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Purple Royale - Blog of Pavlos</title>
-	<meta name="description"
-		content="The website and blog of Pavlos, where he writes about code and codes about stuff." data-rh="true" />
-	<link rel="icon" type="image/svg+xml" href="/favicon.svg" data-rh="true" />
-	<!-- <link rel="icon" type="image/png" href="/icon-light.png" media="(prefers-color-scheme: light)" data-rh="true" /> -->
-	<!-- <link rel="icon" type="image/png" href="/icon-dark.png" media="(prefers-color-scheme: dark)" data-rh="true" /> -->
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+	<!--
+		static defaults, read by link unfurlers and crawlers that do not run js.
+		once react boots, main.tsx strips everything tagged data-static-meta and
+		helmet owns the head, so these never duplicate the per-page tags.
+	-->
+	<title data-static-meta>Purple Royale - Blog of Pavlos</title>
+	<meta data-static-meta name="description"
+		content="The website and blog of Pavlos, where he writes about code and codes about stuff." />
+	<link data-static-meta rel="canonical" href="https://pvin.is/" />
+	<meta data-static-meta property="og:type" content="website" />
+	<meta data-static-meta property="og:site_name" content="Purple Royale" />
+	<meta data-static-meta property="og:title" content="Purple Royale - Blog of Pavlos" />
+	<meta data-static-meta property="og:description"
+		content="The website and blog of Pavlos, where he writes about code and codes about stuff." />
+	<meta data-static-meta property="og:url" content="https://pvin.is/" />
+	<meta data-static-meta name="twitter:card" content="summary" />
+	<meta data-static-meta name="twitter:creator" content="@pvinis" />
 </head>
 
 <body class="bg-background">

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,38 @@
+import { Helmet } from "react-helmet-async"
+import { site } from "../config"
+
+interface SeoProps {
+	title: string
+	description: string
+	/** path this page lives at, e.g. "/posts/my-games". resolved against site.url */
+	path: string
+	favicon?: string
+	article?: { publishedAt: Date }
+}
+
+export function Seo({ title, description, path, favicon, article }: SeoProps) {
+	const url = new URL(path, site.url).toString()
+
+	return (
+		<Helmet>
+			<html lang={site.language} />
+			<title>{title}</title>
+			<meta name="description" content={description} />
+			<link rel="canonical" href={url} />
+
+			<meta property="og:type" content={article ? "article" : "website"} />
+			<meta property="og:site_name" content={site.name} />
+			<meta property="og:title" content={title} />
+			<meta property="og:description" content={description} />
+			<meta property="og:url" content={url} />
+
+			<meta name="twitter:card" content="summary" />
+			<meta name="twitter:creator" content={`@${site.social.twitter}`} />
+
+			{article && <meta property="article:published_time" content={article.publishedAt.toISOString()} />}
+			{article && <meta property="article:author" content={site.author.name} />}
+
+			{favicon && <link rel="icon" href={favicon} />}
+		</Helmet>
+	)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,12 @@ import { Home } from "./pages/Home"
 import { Post } from "./pages/Post"
 import { NotFound } from "./pages/NotFound"
 
+// index.html ships static title/og/canonical defaults for link unfurlers and
+// crawlers that do not run js. helmet appends rather than replacing them, which
+// left the head with two titles and two canonicals, so drop them here and let
+// helmet own it from this point on.
+document.head.querySelectorAll("[data-static-meta]").forEach((el) => el.remove())
+
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>
 		<Providers>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,13 @@
-import { Helmet } from "react-helmet-async"
 import { Link } from "wouter"
 import { posts, formatDate } from "../posts"
 import { site } from "../config"
+import { Seo } from "../components/Seo"
 import profile from "../assets/profile.png"
 
 export function Home() {
 	return (
 		<>
-			<Helmet>
-				<title>{site.title}</title>
-				<meta name="description" content={site.description} />
-			</Helmet>
+			<Seo title={site.title} description={site.description} path="/" />
 
 			<h1 className="mb-2">{site.name}</h1>
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,14 +1,11 @@
-import { Helmet } from "react-helmet-async"
 import { Link } from "wouter"
 import { site } from "../config"
+import { Seo } from "../components/Seo"
 
 export function NotFound() {
 	return (
 		<>
-			<Helmet>
-				<title>{`4 oh 4 - ${site.name}`}</title>
-				<meta name="description" content="Page not found" />
-			</Helmet>
+			<Seo title={`4 oh 4 - ${site.name}`} description="Page not found" path="/404" />
 
 			<h1>404</h1>
 			<p>Nothing here.</p>

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,8 +1,8 @@
-import { Helmet } from "react-helmet-async"
 import { Link } from "wouter"
 import { MDRenderer } from "../components/MDRenderer"
 import { getPost, formatDate } from "../posts"
 import { site } from "../config"
+import { Seo } from "../components/Seo"
 import { NotFound } from "./NotFound"
 
 interface PostProps {
@@ -24,11 +24,13 @@ export function Post({ slug }: PostProps) {
 
 	return (
 		<>
-			<Helmet>
-				<title>{`${attributes.title} - ${site.name}`}</title>
-				<meta name="description" content={description} />
-				{favicon && <link rel="icon" href={favicon} />}
-			</Helmet>
+			<Seo
+				title={`${attributes.title} - ${site.name}`}
+				description={description}
+				path={`/posts/${post.slug}`}
+				favicon={favicon}
+				article={{ publishedAt: post.date }}
+			/>
 
 			<h1 className="mb-1">
 				{attributes.draft && <span className="mr-2 opacity-60">[draft]</span>}


### PR DESCRIPTION
you asked for the correct url everywhere. turns out the url was mostly already right, the problem is nothing was **rendering** it.

- `src/config.ts` already had `https://pvin.is`
- the github homepage field is already `https://pvin.is`
- the readme is fixed in #12

but no page emitted a canonical, an `og:url`, or any og tag at all. so the domain existed in config and nowhere a browser could see it.

### what this does

new `src/components/Seo.tsx` builds every head tag off `site.url`, so the domain is declared once and derived everywhere. `Home`, `Post` and `NotFound` all go through it.

| page | canonical / og:url |
|---|---|
| `/` | `https://pvin.is/` |
| `/posts/my-games` | `https://pvin.is/posts/my-games` |
| `/posts/december-challenge-4` | `https://pvin.is/posts/december-challenge-4` |

posts also get `og:type=article`, `article:published_time` from the post date, and `article:author`.

### the duplication bug

this is the part worth reading.

helmet **appends** to the head, it does not replace what `index.html` already put there. so every page has been serving **two `<title>` tags** since the repo was created, one static and one from helmet.

that means naively adding static og tags for unfurlers would have produced two canonicals and two `og:url`s, which is worse than having none, because a crawler just picks whichever it feels like.

so: the static defaults in `index.html` are tagged `data-static-meta`, and `main.tsx` strips them before react renders.

```js
document.head.querySelectorAll("[data-static-meta]").forEach((el) => el.remove())
```

- a crawler or link unfurler that does not run js reads them straight from the html
- a browser drops them on boot and helmet owns the head from there

best of both, and the pre-existing double `<title>` is fixed as a side effect.

### verified

against a real `vite preview`, counting tags in the live DOM:

```
/                            titles=1 canon=1 ogurl=1  url=https://pvin.is/
/posts/my-games              titles=1 canon=1 ogurl=1  url=https://pvin.is/posts/my-games
/posts/december-challenge-4  titles=1 canon=1 ogurl=1  url=https://pvin.is/posts/december-challenge-4
```

before this change those were `titles=2 canon=2 ogurl=2`.

`dist/index.html` still carries the static defaults, confirmed by grep, so the no-js path works. homepage still lists all 11 posts, console clean, typecheck and build green.

### still not solved

per-post og tags are only visible to things that run js. slack, imessage and friends will unfurl every post as the site-level default. properly fixing that needs prerendering or an SSG, which is the option C we set aside at the start.

no `og:image` either. worth pointing at the rainbow logo that #12 brings over, but that wants a decision on which crop, so leaving it.