### PR TITLE
feat: redirect old /post/* urls to /posts/*

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
+	"redirects": [{ "source": "/post/:slug", "destination": "/posts/:slug", "permanent": true }],
 	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
last piece before pvin.is can go live.

the old next.js blog served posts from `pages/post/[slug].js`, so its urls were **`/post/<slug>`**, singular. this app routes **`/posts/:slug`**, plural.

so the moment pvin.is points here, every link to the old blog that exists anywhere out in the world lands on a 404. one 301 fixes all eleven at once:

```
/post/my-games        ->  /posts/my-games
/post/init-commit     ->  /posts/init-commit
...
```

this is the entire reason #8 kept bare slugs instead of switching to date-prefixed filenames. with `2021-02-12-my-games.md` this would have needed eleven hand-written mappings instead of one rule.

vercel applies `redirects` before `rewrites`, so this runs ahead of the SPA catch-all and does not get swallowed by it.

### not covered

the old site also published feeds at `/feed/atom.xml`, `/feed/feed.xml` and `/feed/feed.json`. those still 404, since this app does not generate feeds. pointing them at `/` would just be a soft 404, so leaving them honestly broken until there is something real to serve. worth knowing if anyone was subscribed.

### verifying

cannot be tested locally, `vercel.json` only takes effect on a vercel deploy. once merged and pvin.is is attached, `curl -I https://pvin.is/post/my-games` should give a `301` to `/posts/my-games`.