### PR TITLE
feat: keep drafts off the home page

### DIFF
--- a/src/posts.ts
+++ b/src/posts.ts
@@ -23,12 +23,18 @@ function toPost(path: string, raw: string): Post {
 	return { slug, date: new Date(attributes.date), body, attributes }
 }
 
-export const posts: Post[] = Object.entries(files)
+const allPosts: Post[] = Object.entries(files)
 	.map(([path, raw]) => toPost(path, raw))
 	.sort((a, b) => b.date.getTime() - a.date.getTime())
 
+// what the home page lists. drafts stay reachable at their own url, they just
+// do not get advertised. still listed in dev so you can find the thing you are
+// in the middle of writing.
+export const posts: Post[] = allPosts.filter((post) => import.meta.env.DEV || !post.attributes.draft)
+
+// any post by slug, drafts included, so a draft url keeps working in production.
 export function getPost(slug: string): Post | undefined {
-	return posts.find((post) => post.slug === slug)
+	return allPosts.find((post) => post.slug === slug)
 }
 
 // UTC, otherwise a late-evening timestamp like init-commit's 22:41Z renders as


### PR DESCRIPTION
drafts stay public and still work at their own url, they just do not get advertised on the index anymore.

### what changed

only `src/posts.ts`. the full list is now private, and it exports two things:

- **`posts`** — filtered, what `Home.tsx` maps over
- **`getPost`** — still searches everything, so `/posts/crash-heaven` keeps working in production

`Home.tsx` is untouched. it still imports `posts` and maps over it, it just gets a shorter array now.

### drafts still show in dev

same as the old blog did it, via `draftsFilter` and `isDev` in `lib/helpers.js`. otherwise you cannot find the thing you are half way through writing without typing the url from memory. the `[draft]` badge stays on the post itself in both modes.

### verified

| | home page lists | `/posts/crash-heaven` |
|---|---|---|
| `bun run preview` (prod) | **9 posts**, no drafts | 200, renders, `[draft]` badge |
| `bun run dev` | **11 posts**, drafts badged | 200, renders, `[draft]` badge |

typecheck and build green.

### note

with `import.meta.glob` the draft markdown is still in the js bundle, so "not on the home page" is not "secret". you said drafts public, so that is fine, just saying it out loud. if you ever want one genuinely private it has to stay out of the repo.