### PR TITLE
content: retitle december-challenge-4

### DIFF
--- a/src/posts/december-challenge-4.md
+++ b/src/posts/december-challenge-4.md
@@ -1,5 +1,5 @@
 ---
-title: "December Challenge #4"
+title: "December Challenge #4 - My own Youtube Watch Later viewer"
 date: 2024-12-10T00:00:00.000Z
 faviconEmoji: "🎄"
 tags: ["december challenge"]


### PR DESCRIPTION
```diff
- title: "December Challenge #4"
+ title: "December Challenge #4 - My own Youtube Watch Later viewer"
```

says what the post is actually about. the old title only told you it was day 4 of something.

**slug is unchanged**, so https://pvin.is/posts/december-challenge-4 and every link to it keeps working. the title lives in frontmatter, the url comes from the filename, so these move independently.

### renders

h1 wraps to three lines at desktop width, looks fine:

> **December Challenge #4 -**
> **My own Youtube Watch**
> **Later viewer**

the home page entry and the `og:title` pick it up automatically since both read the same frontmatter.

### one thing worth knowing

the browser tab title is `{post title} - {site name}`, so this one is now:

```
December Challenge #4 - My own Youtube Watch Later viewer - Purple Royale
```

73 characters, with two ` - ` separators. google truncates around 60, so it will get cut in search results. not changing anything here, just flagging it in case you would rather the site name were dropped from long titles, or the post used a `description` for the subtitle instead of folding it into the title.

typecheck and build green.