### PR TITLE
fix: show the full blog title, and take html lang from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ date: 2021-02-12T11:41:32.169Z
 description: optional, shown under the title on the index
 draft: true
 faviconEmoji: "🎄"
+external: https://somewhere.else/the-real-post
 ---
 
 post body here
 ```
 
 Only `title` and `date` are required. `draft: true` badges the post `[draft]` but still publishes it. Posts are sorted newest first and dates render in UTC.
+
+`external` turns the entry into a link post, for something published on another site. The index links the title straight there with a `↗` and shows the host next to the date, while the date itself still links to the local page, which keeps your own blurb plus a pointer to the original. Feeds send readers to the other site too, but keep this site's url as the item id, so nothing looks like a repost. The canonical url stays ours, since a paragraph of context is not a duplicate of the article it points at.
 
 There is no index to update. `src/posts.ts` picks up the folder with `import.meta.glob`, which vite resolves at build time.
 

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -57,6 +57,11 @@ const url = (path: string) => `${site.url}${path}`
 const postUrl = (post: Post) => url(`/posts/${post.slug}`)
 const summary = (post: Post) => post.attributes.description ?? `Post: ${post.attributes.title}`
 
+// a link post points at someone else's site, so that is where the feed item
+// sends people. the id/guid stays our own permalink, so a reader who already
+// has the item does not see it again as something new.
+const linkFor = (post: Post) => post.attributes.external ?? postUrl(post)
+
 // ---------------------------------------------------------------- pages
 
 // every post gets a file, drafts included, so their urls keep working. drafts
@@ -115,8 +120,8 @@ ${entries
 	.map(
 		({ post, html }) => `		<item>
 			<title>${escapeXml(post.attributes.title)}</title>
-			<link>${escapeXml(postUrl(post))}</link>
-			<guid isPermaLink="true">${escapeXml(postUrl(post))}</guid>
+			<link>${escapeXml(linkFor(post))}</link>
+			<guid isPermaLink="${post.attributes.external ? "false" : "true"}">${escapeXml(postUrl(post))}</guid>
 			<pubDate>${post.date.toUTCString()}</pubDate>
 			<description>${escapeXml(summary(post))}</description>
 			<content:encoded xmlns:content="http://purl.org/rss/1.0/modules/content/">${cdata(html)}</content:encoded>
@@ -143,7 +148,7 @@ ${entries
 		({ post, html }) => `	<entry>
 		<title>${escapeXml(post.attributes.title)}</title>
 		<id>${escapeXml(postUrl(post))}</id>
-		<link href="${escapeXml(postUrl(post))}" />
+		<link href="${escapeXml(linkFor(post))}" />
 		<updated>${post.date.toISOString()}</updated>
 		<published>${post.date.toISOString()}</published>
 		<summary>${escapeXml(summary(post))}</summary>
@@ -165,6 +170,8 @@ const jsonFeed = {
 	items: entries.map(({ post, html }) => ({
 		id: postUrl(post),
 		url: postUrl(post),
+		// json feed 1.1 has a field for exactly this. left out entirely on normal posts.
+		...(post.attributes.external ? { external_url: post.attributes.external } : {}),
 		title: post.attributes.title,
 		summary: summary(post),
 		content_html: html,

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -30,7 +30,10 @@ async function writeFileAt(relativePath: string, contents: string) {
 async function prerender(url: string, outPath: string) {
 	const { html, head } = render(url)
 
-	const page = template.replace("<!--app-head-->", head).replace("<!--app-html-->", html)
+	const page = template
+		.replace('<html lang="en">', `<html lang="${site.language}">`)
+		.replace("<!--app-head-->", head)
+		.replace("<!--app-html-->", html)
 
 	await writeFileAt(outPath, page)
 	return page

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { Link } from "wouter"
-import { posts, formatDate } from "../posts"
+import { posts, formatDate, externalHost } from "../posts"
 import { site } from "../config"
 import profile from "../assets/profile.png"
 
@@ -16,18 +16,50 @@ export function Home() {
 				</p>
 			</div>
 
-			{posts.map((post) => (
-				<article key={post.slug} className="mb-10">
-					<h2 className="mb-1">
-						<Link href={`/posts/${post.slug}`} className="text-accent no-underline hover:underline">
-							{post.attributes.draft && <span className="mr-2 opacity-60">[draft]</span>}
-							{post.attributes.title}
-						</Link>
-					</h2>
-					<span className="text-sm opacity-70">{formatDate(post.date)}</span>
-					{post.attributes.description && <p className="mt-2">{post.attributes.description}</p>}
-				</article>
-			))}
+			{posts.map((post) => {
+				const { title, description, draft, external } = post.attributes
+				const permalink = `/posts/${post.slug}`
+
+				// built once, so the badge and title are not spelled out in both branches below.
+				const heading = (
+					<>
+						{draft && <span className="mr-2 opacity-60">[draft]</span>}
+						{title}
+						{external && <span aria-hidden> ↗</span>}
+					</>
+				)
+
+				return (
+					<article key={post.slug} className="mb-10">
+						<h2 className="mb-1">
+							{external ? (
+								<a href={external} className="text-accent no-underline hover:underline">
+									{heading}
+								</a>
+							) : (
+								<Link href={permalink} className="text-accent no-underline hover:underline">
+									{heading}
+								</Link>
+							)}
+						</h2>
+						<span className="text-sm opacity-70">
+							{external ? (
+								// the title leaves the site, so the date carries the local permalink.
+								// without it that page would only be reachable from the feeds.
+								<>
+									<Link href={permalink} className="text-inherit no-underline hover:underline">
+										{formatDate(post.date)}
+									</Link>{" "}
+									· {externalHost(external)}
+								</>
+							) : (
+								formatDate(post.date)
+							)}
+						</span>
+						{description && <p className="mt-2">{description}</p>}
+					</article>
+				)
+			})}
 		</>
 	)
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import profile from "../assets/profile.png"
 export function Home() {
 	return (
 		<>
-			<h1 className="mb-2">{site.name}</h1>
+			<h1 className="mb-2">{site.title}</h1>
 
 			<div className="mb-14 flex items-center gap-3 not-prose">
 				<img src={profile} alt="" className="h-14 w-14 shrink-0 rounded-full" />

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,6 +1,6 @@
 import { Link } from "wouter"
 import { MDRenderer } from "../components/MDRenderer"
-import { getPost, formatDate } from "../posts"
+import { getPost, formatDate, externalHost } from "../posts"
 import { NotFound } from "./NotFound"
 
 interface PostProps {
@@ -13,6 +13,7 @@ export function Post({ slug }: PostProps) {
 	if (!post) return <NotFound />
 
 	const { attributes } = post
+	const { external } = attributes
 
 	return (
 		<>
@@ -20,7 +21,20 @@ export function Post({ slug }: PostProps) {
 				{attributes.draft && <span className="mr-2 opacity-60">[draft]</span>}
 				{attributes.title}
 			</h1>
-			<p className="mt-0 mb-10 text-sm opacity-70">{formatDate(post.date)}</p>
+			<p className={`mt-0 text-sm opacity-70 ${external ? "mb-2" : "mb-10"}`}>
+				{formatDate(post.date)}
+			</p>
+
+			{/* the real article is elsewhere, so say it above the body. someone who got
+			    here from a feed should not have to read to the end to find that out. */}
+			{external && (
+				<p className="mt-0 mb-10 text-sm">
+					Originally published on{" "}
+					<a href={external} className="text-accent">
+						{externalHost(external)} ↗
+					</a>
+				</p>
+			)}
 
 			<MDRenderer text={post.body} />
 

--- a/src/posts.ts
+++ b/src/posts.ts
@@ -39,6 +39,12 @@ export function getPost(slug: string): Post | undefined {
 	return allPosts.find((post) => post.slug === slug)
 }
 
+// where a link post actually points, for the "· artsy.github.io" line on the
+// index. the host alone is enough to tell a reader they are leaving.
+export function externalHost(url: string): string {
+	return new URL(url).hostname.replace(/^www\./, "")
+}
+
 // UTC, otherwise a late-evening timestamp like init-commit's 22:41Z renders as
 // the next day for anyone east of greenwich.
 export function formatDate(date: Date): string {

--- a/src/posts/typescript-magic.md
+++ b/src/posts/typescript-magic.md
@@ -1,0 +1,13 @@
+---
+title: TypeScript magic
+date: 2023-03-01T00:00:00.000Z
+description: "The string & {} trick, which keeps autocomplete on a union while still accepting any string."
+tags: ["elsewhere"]
+external: https://artsy.github.io/blog/2023/03/01/typescript-magic/
+---
+
+Back when I was at Artsy, I wrote a post for the engineering blog about a TypeScript trick I kept reaching for.
+
+The short version: write `"hello" | "world" | string` and TypeScript collapses the whole thing down to `string`, so the autocomplete you wanted is gone. Write `"hello" | "world" | (string & {})` instead and the suggestions stick around, while the type still accepts any string at all.
+
+We used it in `palette-mobile`, so a color prop would suggest `black100` and friends and still happily take `#000000`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,4 +6,6 @@ export type SupportedFrontMatter = {
 	description?: string
 	tags?: string[]
 	draft?: boolean
+	/** set when the post really lives on another site. the index links straight there. */
+	external?: string
 }


### PR DESCRIPTION
stacked on #18. two gaps found while double checking what helmet used to do for us.

### the blog title

you asked to **keep both names, "Purple Royale - Blog of Pavlos"**. that string was only ever reaching the browser tab. the visible heading on the home page just said "Purple Royale", because it rendered `site.name` instead of `site.title`.

```diff
- <h1 className="mb-2">{site.name}</h1>
+ <h1 className="mb-2">{site.title}</h1>
```

wraps to two lines at desktop width. `og:site_name` stays the short "Purple Royale", which is correct, that field is meant to be the short form.

### html lang

`index.html` hardcoded `lang="en"` while `config.ts` says `"en-US"`. helmet used to set this from config and nothing did after it was removed. prerender writes it from config now, so there is one source of truth:

```
<html lang="en-US">
```