### PR TITLE
fix: middle dot instead of a dash in the blog title

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const site = {
-	title: "Purple Royale - Blog of Pavlos",
+	title: "Purple Royale · Blog of Pavlos",
 	name: "Purple Royale",
 	description: "The website and blog of Pavlos, where he writes about code and codes about stuff.",
 	url: "https://pvin.is",


### PR DESCRIPTION
Keeps both names, swaps the dash for a middle dot.

```diff
-title: "Purple Royale - Blog of Pavlos",
+title: "Purple Royale · Blog of Pavlos",
```

`·` is `U+00B7 MIDDLE DOT` — the same separator the index already uses between a link post's date and its host (`March 1, 2023 · artsy.github.io`), so the two now match.

## Scope

One line in `src/config.ts`. `site.title` feeds the home page `<h1>`, the home `<title>` tag, and `og:title`.

Post pages are **not** affected: they build their title from `site.name`, so `My Games - Purple Royale` stays exactly as it was. Say the word if you want that separator changed too — it's a different string and a different call.

## Ordering

**This can merge in any order relative to #21.** It only touches `src/config.ts`, which neither #19 nor #20 goes near, so there's no conflict either way.

One caveat worth knowing: the dot won't be *visible* on the home page heading until #21 lands. `main` today still renders `{site.name}` in the `<h1>` — that's the bug #19 fixed, and #19 is one of the two PRs stranded off `main`. Until #21 merges, this change shows up in the browser tab and the og tags, but the on-page heading still reads just "Purple Royale".

## Verification

- `bun run typecheck` clean.
- `bun run build` clean, `12 pages + 404, 9 in sitemap and feeds` — unchanged, as expected.
- `dist/index.html` → `<title>Purple Royale · Blog of Pavlos</title>` and matching `og:title`.
- `dist/posts/my-games.html` → `<title>My Games - Purple Royale</title>`, confirming post titles were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
