### PR TITLE
fix: keep the homepage row as it was, and let the date sit under its title

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ post body here
 
 Only `title` and `date` are required. `draft: true` badges the post `[draft]` but still publishes it. Posts are sorted newest first and dates render in UTC.
 
-`external` turns the entry into a link post, for something published on another site. The index links the title straight there with a `↗` and shows the host next to the date, while the date itself still links to the local page, which keeps your own blurb plus a pointer to the original. Feeds send readers to the other site too, but keep this site's url as the item id, so nothing looks like a repost. The canonical url stays ours, since a paragraph of context is not a duplicate of the article it points at.
+`external` turns the entry into a link post, for something published on another site. On the index the title links straight there, marked with a `↗`, and nothing else about the row changes. The post still has a page here, holding your own blurb plus a pointer to the original, but nothing on the index links to it, so reach it through the feeds or the url. Feeds send readers to the other site too, but keep this site's url as the item id, so nothing looks like a repost. The canonical url stays ours, since a paragraph of context is not a duplicate of the article it points at.
 
 There is no index to update. `src/posts.ts` picks up the folder with `import.meta.glob`, which vite resolves at build time.
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { Link } from "wouter"
-import { posts, formatDate, externalHost } from "../posts"
+import { posts, formatDate } from "../posts"
 import { site } from "../config"
 import profile from "../assets/profile.png"
 
@@ -42,20 +42,7 @@ export function Home() {
 								</Link>
 							)}
 						</h2>
-						<span className="text-sm opacity-70">
-							{external ? (
-								// the title leaves the site, so the date carries the local permalink.
-								// without it that page would only be reachable from the feeds.
-								<>
-									<Link href={permalink} className="text-inherit no-underline hover:underline">
-										{formatDate(post.date)}
-									</Link>{" "}
-									· {externalHost(external)}
-								</>
-							) : (
-								formatDate(post.date)
-							)}
-						</span>
+						<span className="text-sm opacity-70">{formatDate(post.date)}</span>
 						{description && <p className="mt-2">{description}</p>}
 					</article>
 				)

--- a/src/posts/typescript-magic.md
+++ b/src/posts/typescript-magic.md
@@ -1,7 +1,6 @@
 ---
 title: TypeScript magic
 date: 2023-03-01T00:00:00.000Z
-description: "The string & {} trick, which keeps autocomplete on a union while still accepting any string."
 tags: ["elsewhere"]
 external: https://artsy.github.io/blog/2023/03/01/typescript-magic/
 ---


### PR DESCRIPTION
Trims the homepage row back to a title and a date. The `↗` is the only sign a post points off site.

This commit existed on `recover/site-title-and-link-posts`, but #21 was merged from that branch's earlier state (`afbfb97`'s parent is `db703b4`, not `4d2e7a0`), so it never travelled to `main`. Cherry-picked here rather than merged, because the branch predates #22 and a merge would have dragged a stale `src/config.ts` along with it.

## What changes

**Before, on `main` right now:**

```
TypeScript magic ↗
March 1, 2023 · artsy.github.io
The string & {} trick, which keeps autocomplete on a union while still accepting any string.
```

**After:**

```
TypeScript magic ↗
March 1, 2023
```

Three things go:

- the `· artsy.github.io` label after the date
- the date-as-permalink link
- the `description` on `typescript-magic.md`, so no text sits under the entry

`config-manifesto` and `crash-heaven` also carry descriptions, but both are drafts and never render in production — so this was the only one showing, and the index is back to titles and dates throughout.

## Consequences worth naming

1. **`/posts/typescript-magic` is no longer linked from the index.** It still exists, still prerenders, and is still in the sitemap and all three feeds. You reach it through a feed or the url. That's inherent to the arrow being the only affordance.
2. **Dropping the description weakens that page's metadata.** `seo.ts` falls back to `Post: TypeScript magic` for both `<meta name="description">` and the feed summary. The alternative — keep the frontmatter field and instead drop the description render from the index — looks identical on screen but keeps real metadata for search and feeds. One line either way; happy to switch it.

## Verification

- `bun run typecheck` clean.
- `bun run build` clean, `13 pages + 404, 10 in sitemap and feeds`.
- `dist/index.html`: entry is `TypeScript magic ↗` then a plain `March 1, 2023`. **Zero** description paragraphs and **zero** host labels on the page.
- `<h1>Purple Royale · Blog of Pavlos</h1>` — #22's middle dot is intact, confirming the cherry-pick didn't regress it.
- `dist/posts/typescript-magic.html` keeps its "Originally published on artsy.github.io ↗" pointer.
- Net `Home.tsx` diff against `main` is −17/+3: the host label and permalink branch removed, external link and arrow kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: the date now sits under its title

Pushed after the original description above. The `<h2>` already said `mb-1`, but it was not winning.

All three rules have identical specificity (`0,1,0`), so source order decides:

| rule | byte offset in the built CSS |
|---|---|
| `.prose :where(h2)` | 9,346 |
| `.mb-1` | 18,542 |
| `.lg:prose-xl :where(h2)` | 20,930 |

So `mb-1` won below `lg`, but from `lg` up `lg:prose-xl` came later and applied `margin-bottom: 0.888889em` to a `1.8em` heading — **32px instead of 4px**.

Measured in Chrome at 1440px: the date sat **43px** below its own title, almost exactly as far as the *next* post's title, so it read as floating between two entries rather than belonging to either.

`mb-1!` makes the existing intent apply. Measured after:

| width | h2 font-size | margin-bottom | visual gap |
|---|---|---|---|
| 1440 | 36px | 4px | 43px → **15px** |
| 1024 | 36px | 4px | 43px → **15px** |
| 768 | 24px | 4px | **10px** (unchanged) |
| 390 | 24px | 4px | **10px** (unchanged) |

Below `lg` nothing changes — `mb-1` was already winning there. This only ever affected desktop.
