### PR TITLE
feat: add a projects page

### DIFF
--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -69,6 +69,7 @@ const linkFor = (post: Post) => post.attributes.external ?? postUrl(post)
 // feeds below.
 const routes = [
 	{ url: "/", out: "index.html" },
+	{ url: "/projects", out: "projects.html" },
 	...allPosts.map((post: Post) => ({ url: `/posts/${post.slug}`, out: `posts/${post.slug}.html` })),
 ]
 
@@ -88,6 +89,10 @@ const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 	<url>
 		<loc>${escapeXml(site.url)}</loc>
 		<changefreq>weekly</changefreq>
+	</url>
+	<url>
+		<loc>${escapeXml(url("/projects"))}</loc>
+		<changefreq>monthly</changefreq>
 	</url>
 ${posts
 	.map(
@@ -185,6 +190,6 @@ await writeFileAt("feed/atom.xml", atom)
 await writeFileAt("feed/feed.json", `${JSON.stringify(jsonFeed, null, 2)}\n`)
 
 console.log(
-	`prerendered ${routes.length} pages + 404, ${posts.length} in sitemap and feeds ` +
-		`(${allPosts.length - posts.length} drafts noindexed)`,
+	`prerendered ${routes.length} pages + 404, ${routes.length - allPosts.length + posts.length} in sitemap, ` +
+		`${posts.length} in feeds (${allPosts.length - posts.length} drafts noindexed)`,
 )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Route, Router, Switch } from "wouter"
+import { SiteHeader } from "./components/SiteHeader"
 import { Home } from "./pages/Home"
 import { Post } from "./pages/Post"
 import { Projects } from "./pages/Projects"
@@ -23,6 +24,8 @@ function Shell() {
 
 	return (
 		<div className="prose prose-quoteless bg-background lg:prose-xl dark:prose-invert prose-blockquote:font-normal prose-blockquote:text-gray-400 mx-auto max-w-prose px-6 pt-32 pb-16 2xl:max-w-[1000px]">
+			<SiteHeader />
+
 			<Switch>
 				<Route path="/" component={Home} />
 				<Route path="/projects" component={Projects} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Router, Switch } from "wouter"
 import { Home } from "./pages/Home"
 import { Post } from "./pages/Post"
+import { Projects } from "./pages/Projects"
 import { NotFound } from "./pages/NotFound"
 import { useDocumentTitle } from "./useDocumentTitle"
 
@@ -24,6 +25,7 @@ function Shell() {
 		<div className="prose prose-quoteless bg-background lg:prose-xl dark:prose-invert prose-blockquote:font-normal prose-blockquote:text-gray-400 mx-auto max-w-prose px-6 pt-32 pb-16 2xl:max-w-[1000px]">
 			<Switch>
 				<Route path="/" component={Home} />
+				<Route path="/projects" component={Projects} />
 				<Route path="/posts/:slug">{(params) => <Post slug={params.slug} />}</Route>
 				<Route component={NotFound} />
 			</Switch>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,36 @@
+import { Link } from "wouter"
+import { site } from "../config"
+
+/**
+ * Sits above the title on every page, so posts and /projects get it too and not
+ * just the home page.
+ *
+ * The site name lives here now, which is why the home page heading is only the
+ * tagline. Repeating "Purple Royale" twice, once here and once as the h1 right
+ * underneath, read as a mistake.
+ */
+export function SiteHeader() {
+	return (
+		<nav className="not-prose border-on-background/15 mb-12 flex items-baseline justify-between gap-4 border-b pb-3">
+			<Link href="/" className="text-on-background font-semibold no-underline">
+				{site.name}
+			</Link>
+
+			<span className="flex gap-4 text-sm">
+				<Link href="/" className="text-accent no-underline hover:underline">
+					posts
+				</Link>
+				<Link href="/projects" className="text-accent no-underline hover:underline">
+					projects
+				</Link>
+				<a
+					href={`https://github.com/${site.social.github}`}
+					className="text-accent no-underline hover:underline"
+					rel="noreferrer"
+				>
+					github ↗
+				</a>
+			</span>
+		</nav>
+	)
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,10 @@
 export const site = {
+	/** the full thing, for <title> and og. */
 	title: "Purple Royale · Blog of Pavlos",
+	/** short form. the site header and og:site_name. */
 	name: "Purple Royale",
+	/** the home page h1, since the header above it already says the name. */
+	tagline: "Blog of Pavlos",
 	description: "The website and blog of Pavlos, where he writes about code and codes about stuff.",
 	url: "https://pvin.is",
 	language: "en-US",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,14 +6,12 @@ import profile from "../assets/profile.png"
 export function Home() {
 	return (
 		<>
-			<h1 className="mb-2">{site.title}</h1>
+			<h1 className="mb-2">{site.tagline}</h1>
 
 			<div className="mb-14 flex items-center gap-3 not-prose">
 				<img src={profile} alt="" className="h-14 w-14 shrink-0 rounded-full" />
 				<p className="text-on-background text-base leading-7">
-					Written by <b className="font-semibold">{site.author.name}</b> {site.author.summary}{" "}
-					<a href={`https://github.com/${site.social.github}`}>You can find him on github</a>, or see
-					what he has <Link href="/projects">worked on</Link>.
+					Written by <b className="font-semibold">{site.author.name}</b> {site.author.summary}
 				</p>
 			</div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,8 @@ export function Home() {
 				<img src={profile} alt="" className="h-14 w-14 shrink-0 rounded-full" />
 				<p className="text-on-background text-base leading-7">
 					Written by <b className="font-semibold">{site.author.name}</b> {site.author.summary}{" "}
-					<a href={`https://github.com/${site.social.github}`}>You can find him on github</a>.
+					<a href={`https://github.com/${site.social.github}`}>You can find him on github</a>, or see
+					what he has <Link href="/projects">worked on</Link>.
 				</p>
 			</div>
 

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,4 +1,3 @@
-import { Link } from "wouter"
 import { projects } from "../projects"
 
 export function Projects() {
@@ -7,7 +6,7 @@ export function Projects() {
 			<h1 className="mb-2">Projects</h1>
 			<p className="mt-0 mb-12 text-sm opacity-70">Things I have worked on. Everything here is live.</p>
 
-			<ul className="not-prose mb-14 flex flex-col gap-3">
+			<ul className="not-prose flex flex-col gap-3">
 				{projects.map((project) => (
 					<li key={project.url} className="flex items-baseline gap-3">
 						<a
@@ -21,11 +20,6 @@ export function Projects() {
 					</li>
 				))}
 			</ul>
-
-			<hr />
-			<Link href="/" className="text-accent no-underline hover:underline">
-				back to all posts
-			</Link>
 		</>
 	)
 }

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,0 +1,31 @@
+import { Link } from "wouter"
+import { projects } from "../projects"
+
+export function Projects() {
+	return (
+		<>
+			<h1 className="mb-2">Projects</h1>
+			<p className="mt-0 mb-12 text-sm opacity-70">Things I have worked on. Everything here is live.</p>
+
+			<ul className="not-prose mb-14 flex flex-col gap-3">
+				{projects.map((project) => (
+					<li key={project.url} className="flex items-baseline gap-3">
+						<a
+							href={project.url}
+							className="text-accent text-base no-underline hover:underline"
+							rel="noreferrer"
+						>
+							{project.name}
+						</a>
+						<span className="text-xs opacity-50">{project.tag}</span>
+					</li>
+				))}
+			</ul>
+
+			<hr />
+			<Link href="/" className="text-accent no-underline hover:underline">
+				back to all posts
+			</Link>
+		</>
+	)
+}

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,65 @@
+/**
+ * Things Pavlos has worked on.
+ *
+ * A flat list on purpose, ordered by hand rather than by date. Adding one is a
+ * single entry, no build step and nothing to keep in sync.
+ *
+ * Every url here was checked and answered 200. If one dies, it should go, a
+ * portfolio of dead links is worse than a short one.
+ */
+export type ProjectTag = "app" | "site" | "oss" | "package" | "talk" | "video" | "contribution" | "silly"
+
+export interface Project {
+	name: string
+	url: string
+	tag: ProjectTag
+}
+
+export const projects: Project[] = [
+	// things people can actually use
+	{ name: "LeanScaper", url: "https://apps.apple.com/us/app/leanscaper-ai/id6754711316", tag: "app" },
+	{ name: "LeanScaper website", url: "https://leanscaper.com", tag: "site" },
+	{ name: "Autographer", url: "https://apps.apple.com/us/app/autographer/id6499551485", tag: "app" },
+	{ name: "Hour Bell", url: "https://quad.codes/hour-bell", tag: "app" },
+	{ name: "Browsers Party", url: "https://browsers.party", tag: "site" },
+	{ name: "Markdown Viewer", url: "https://md.quad.codes", tag: "site" },
+	{ name: "PaceVer", url: "https://pacever.org", tag: "site" },
+	{ name: "Crypto Icons", url: "https://crypto-icons.dev", tag: "site" },
+	{ name: "Kardiologos Agapitou", url: "https://kardiologos-agapitou.gr", tag: "site" },
+	{ name: "Taxpedia", url: "https://taxpedia.gr", tag: "site" },
+	{ name: "Artsy Salon 2022", url: "https://salon-2022.pvinis.art", tag: "site" },
+
+	// code other people use
+	{ name: "react-native-xcodegen", url: "https://github.com/pvinis/react-native-xcodegen", tag: "oss" },
+	{ name: "colortools", url: "https://github.com/pvinis/colortools", tag: "oss" },
+	{ name: "iosevka-webfont", url: "https://github.com/pvinis/iosevka-webfont", tag: "oss" },
+	{ name: "textworm", url: "https://github.com/pvinis/textworm", tag: "oss" },
+	{ name: "flick", url: "https://github.com/pvinis/flick", tag: "oss" },
+	{ name: "i-kick-you-out", url: "https://github.com/pvinis/i-kick-you-out", tag: "oss" },
+	{ name: "catapult", url: "https://github.com/pvinis/catapult", tag: "oss" },
+	{ name: "update-cloudflare-dns", url: "https://github.com/pvinis/update-cloudflare-dns", tag: "oss" },
+	{ name: "homebrew-pvinis", url: "https://github.com/pvinis/homebrew-pvinis", tag: "oss" },
+	{ name: "react-conditional-wrap", url: "https://jsr.io/@pvinis/react-conditional-wrap", tag: "package" },
+	{ name: "signals-storage", url: "https://jsr.io/@pvinis/signals-storage", tag: "package" },
+
+	{
+		name: "React Native native crash reporting",
+		url: "https://github.com/pvinis/react-native-project-with-crash-heaven-pr",
+		tag: "contribution",
+	},
+
+	// speaking
+	{ name: "xcodegen and React Native", url: "https://github.com/pvinis/talk-xcodegen-rn", tag: "talk" },
+	{ name: "Upgrading React Native", url: "https://github.com/pvinis/talk-upgrading-react-native", tag: "talk" },
+	{ name: "RxJS", url: "https://github.com/pvinis/talk-rxjs", tag: "talk" },
+	{
+		name: "UIExplorer in ClojureScript",
+		url: "https://www.youtube.com/playlist?list=PLmalQP9SU3s4TTRfyox68RBYkEj14X3cb",
+		tag: "video",
+	},
+
+	// not serious, kept on purpose
+	{ name: "notch-troll", url: "https://youtu.be/doEwhLtsACU", tag: "silly" },
+	{ name: "swordsmen", url: "https://github.com/pvinis/swordsmen", tag: "silly" },
+	{ name: "mazical", url: "https://github.com/pvinis/mazical", tag: "silly" },
+]

--- a/src/seo.ts
+++ b/src/seo.ts
@@ -44,6 +44,16 @@ export function headFor(path: string): Head {
 		}
 	}
 
+	if (path === "/projects") {
+		return {
+			title: `Projects - ${site.name}`,
+			description: `Things ${site.author.name} has worked on.`,
+			canonical: canonicalUrl(path),
+			type: "website",
+			noindex: false,
+		}
+	}
+
 	const slug = path.startsWith("/posts/") ? path.slice("/posts/".length) : undefined
 	const post = slug ? getPost(slug) : undefined
 


### PR DESCRIPTION
a flat list of things you have worked on, at **`/projects`**. names and links with a small tag on each, no blurbs, exactly as picked.

**30 entries**, including `kardiologos-agapitou.gr`.

### every url was checked

all 30 answer **200**, following redirects. this is the part worth trusting, a portfolio of dead links is worse than a short one. if one dies later it should come out rather than linger.

### the data

`src/projects.ts` is a typed array, not markdown, since these are records and not prose:

```ts
{ name: "Browsers Party", url: "https://browsers.party", tag: "site" }
```

adding one later is a single line. no new dependency, no build step, nothing to keep in sync.

tags used: `app`, `site`, `oss`, `package`, `talk`, `video`, `contribution`, `silly`.

### crawlable like everything else

prerenders to `dist/projects.html` with its own title and canonical (`https://pvin.is/projects`), readable with no js, and added to the sitemap, which is now 12 urls.

**left out of the feeds** on purpose. it is not a post and would look wrong arriving in someone's reader.

### two judgement calls, easy to reverse

**no years.** i could not verify dates for the client work, and wrong dates on your own portfolio are worse than no dates. the order is curated by hand instead, roughly most-substantial first. reorder the array and the page follows.

**the crash heaven entry** points at [`react-native-project-with-crash-heaven-pr`](https://github.com/pvinis/react-native-project-with-crash-heaven-pr), your companion repo, because github's search api would not let me find the actual `facebook/react-native` PR from here. if you have that link, it is a better target and a one line change.

### not included

the 7 you unticked: `toddo`, `pavlos.pizza`, `finish-h.im`, `ispavloshereyet.com`, `voucher-ping`, `pav.gg/travel-app`, `pavlocoin`. all still live if you change your mind.

### discoverability

linked from the bio line on the home page. without that nothing points at it and nobody would find it.

### verified

```
typecheck            0
build                14 pages + 404, 12 in sitemap, 10 in feeds
/projects            title + canonical correct, 30 links in the markup
client-side nav      home -> /projects, title updates, 1 title element
console              clean
all 30 urls          200
```