### PR TITLE
fix: declare color-scheme and paint the canvas

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -2,9 +2,22 @@
 @plugin "@tailwindcss/typography";
 
 :root {
+	/* tells the browser this page has both modes, so it themes the scrollbar,
+	   the overscroll area and any form controls to match instead of assuming
+	   light. without it a dark page gets a light scrollbar and a black canvas. */
+	color-scheme: light dark;
+
 	--color-background: white;
 	--color-on-background: theme("colors.gray.700");
 	--color-accent: theme("colors.pink.600");
+}
+
+/* paint the canvas itself, not just the body. a short page like /projects does
+   not fill the viewport, and relying on background propagation from body left
+   a bar of browser-default colour below the content. */
+html {
+	background-color: var(--color-background);
+	min-height: 100%;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
the black bar under the content on `/projects`.

### what was happening

`/projects` is short, so on a tall window the page does not fill the viewport. the area below it was being painted by the browser instead of by us.

two separate causes, both fixed here.

**1. `color-scheme` was never declared.** the site has a full dark mode but only ever used `prefers-color-scheme` to pick its own colours. it never told the browser that, so the browser assumed light regardless:

```
before:  colorScheme = normal
after:   colorScheme = light dark
```

that also explains a light scrollbar on a dark page, and would have made any form control render light.

**2. the background only lived on `body`**, relying on the browser propagating it up to the canvas. that propagation is real but conditional, and it was not surviving here. `html` is now painted directly, which removes the guesswork:

```css
html {
	background-color: var(--color-background);
	min-height: 100%;
}
```

### verified

```
$ colorScheme    light dark
$ htmlBg         oklch(0.373 0.034 259.733)   (gray-700, the dark background)
```

and in the built css, so it is not just a dev-server artefact:

```
html{background-color:var(--color-background);min-height:100%}
color-scheme:light dark
```

### note

i could not reproduce the bar in headless chrome, it rendered the background correctly there. but `color-scheme: normal` on a site with a dark mode is a real bug regardless of which browser shows it, and painting `html` makes the outcome independent of propagation rules. if you still see a bar after this lands, tell me and i will dig into your specific browser.

this affects every page. `/projects` is just where it shows, because it is the only page short enough to leave a gap.