### PR TITLE
feat: declare color-scheme in the html too, and set theme-color

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,22 @@
 <head>
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+	<!--
+		globals.css declares color-scheme too, but it is a separate render-blocking
+		stylesheet, so between parsing this html and that css arriving the browser
+		still assumes light. declaring it here closes that window, which is a white
+		flash on first load for anyone in dark mode.
+
+		theme-color paints the browser ui itself, the address bar on mobile safari
+		and chrome. these two hex values are the light and dark --color-background
+		from globals.css, and have to be literals because they are read before any
+		css exists. if the palette changes, change them here as well.
+	-->
+	<meta name="color-scheme" content="light dark" />
+	<meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+	<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#364153" />
+
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
 	<link rel="alternate" type="application/rss+xml" title="Purple Royale" href="/feed/feed.xml" />


### PR DESCRIPTION
answers "do we need to add something so the browser knows this site does both modes". #27 did most of it. this is the piece it could not cover.

### why the css alone is not enough

`globals.css` declares `color-scheme: light dark`, which is the main mechanism and is already live. but it ships as a **separate render-blocking stylesheet**:

```html
<link rel="stylesheet" crossorigin href="/assets/index-Bp8ZYPAH.css">
```

so between the browser parsing the html and that file arriving, there is no `color-scheme` at all and the browser assumes light. for someone in dark mode that window is a white flash on first load.

`<meta name="color-scheme">` is read during parse, before any css exists, so it closes the gap.

### theme-color

while here, added `theme-color` too. different thing: it paints the **browser ui**, not the page. the address bar on mobile safari and chrome will match the page instead of sitting there white above a dark site.

```html
<meta name="color-scheme" content="light dark" />
<meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#364153" />
```

verified the dark value is exactly what the page renders, rather than eyeballed:

```
actual=#364153  themeColorMeta=#364153  match=true
```

### one wart

those two hex values duplicate `--color-background` from `globals.css`. they have to be literals, because the whole point is that they are read before any css exists. there is a comment next to them saying to change both if the palette moves.

### checks

both tags land in **every** prerendered page, not just `index.html`, since they live in the template the prerender step fills:

```
$ grep 'color-scheme\|theme-color' dist/projects.html
<meta name="color-scheme" content="light dark" />
<meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#364153" />
```

typecheck 0, build green.